### PR TITLE
Update horses.pnml

### DIFF
--- a/src/horses.pnml
+++ b/src/horses.pnml
@@ -56,7 +56,7 @@ item(FEAT_TRAINS, OneHorse) {
 	tractive_effort_coefficient:    1; 
 	air_drag_coefficient:	   	0.9; 
 	running_cost_base:	   	RUNNING_COST_ELECTRIC; 
-        track_type:                     NG60; 
+        track_type:                     Equi; 
         ai_engine_rank:                 0; 
         engine_class:                   ENGINE_CLASS_STEAM; 
 	weight:			 	1; 


### PR DESCRIPTION
Added custom track type so horses can work on wagonways and light rail from Early Rail Set (see TT-Forums or https://perma.cc/R89A-WJBN).